### PR TITLE
Fix user/application authentication docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,14 @@
 # Outstand API Documentation
 
-This is a REST-style API that uses JSON for serialization and [API token](#authentication) authentication. You can only access our API over HTTPS at https://app.outstand.com.
+This is a REST-style API that uses JSON for serialization and [API token](#authentication) authentication. You can only access our API over HTTPS at https://app.outstand.com or your white label URL if you're a corporate customer.
+
+Our API endpoints are broken up into two categories: application level and user level.  Application level endpoints are used by corporate white label customers to manage their white label. User level endpoints are used by both white labels and end users to manage an individual user.
+
+*If you're a normal user, you can just ignore the application level endpoints.*
+
+## Application Level Endpoints
+
+Outstand clients with their own white label can gain access to our [User endpoints](https://github.com/outstand/api-docs/blob/master/user_endpoints.md).
 
 ## Authentication
 
@@ -133,7 +141,3 @@ You can paginate the result set by passing in the following parameters for the r
 When you request a page that does not exist you will receive a ```404 Not Found```.
 
 *Note:* ```page``` defaults to 1 and ```per_page``` defaults to the maximum of 100.
-
-## User Endpoints
-
-Outstand clients with their own white label can gain access to our [User endpoints](https://github.com/outstand/api-docs/blob/master/user_endpoints.md).

--- a/README.md
+++ b/README.md
@@ -80,18 +80,26 @@ You'll receive a `200 OK` with a new `access_token` and `refresh_token` in the r
 
 ### Token Authentication (Deprecated)
 
-Every request must be made with the account's API token in the parameters of the request. Your account's API token can be found on the "User Settings" page inside of the "Your Account" area. For example, to access the contacts endpoint you would use the following:
+Every request must be made with the account's API token in the headers of the request. Your account's API token can be found on the "User Settings" page inside of the "Your Account" area. For example, to access the contacts endpoint you would use the following:
 
 ```
-https://app.outstand.com/api/v1/contacts.json?auth_token=th3t0k3ng035r1ghth3r3
+GET /api/v1/contacts.json HTTP/1.1
+
+Host: app.outstand.com
+<Other standard headers here>
+Authorization: th3t0k3ng035r1ghth3r3
+From: usernamegoeshere
+
 ```
+
+Note: The `From` header can be the user's username or url encoded email address.
 
 ## Endpoints
 
 The current version of the API is v1. This is reflected in the URL used to access the endpoint. For example, to access the contacts endpoint you would use the following:
 
 ```
-/api/v1/contacts.json?auth_token=th3t0k3ng035r1ghth3r3
+/api/v1/contacts.json
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Our API endpoints are broken up into two categories: application level and user 
 
 ## Application Level Endpoints
 
-Outstand clients with their own white label can gain access to our [User endpoints](https://github.com/outstand/api-docs/blob/master/user_endpoints.md).
+Outstand clients with their own white label can gain access to our [Application endpoints](https://github.com/outstand/api-docs/blob/master/application_endpoints.md).
 
 ## Authentication
 

--- a/application_endpoints.md
+++ b/application_endpoints.md
@@ -1,4 +1,4 @@
-# User Endpoints
+# Application Endpoints
 
 ## Authentication
 
@@ -7,7 +7,7 @@ The following endpoints are only available through OAuth2 Client Credentials Flo
 The endpoints described here are considered 'application level endpoints' which is why the oauth tokens you obtain through the client credentials flow aren't tied to a user.  These tokens _cannot_ be used to access 'user level endpoints' and regular user oauth tokens cannot be used to access these application level endpoints.
 
 
-## Introduction
+## User Endpoints
 
 _Note: This API is scoped to your organization’s white label._
 

--- a/user_endpoints.md
+++ b/user_endpoints.md
@@ -1,5 +1,13 @@
 # User Endpoints
+
+## Authentication
+
 The following endpoints are only available through OAuth2 Client Credentials Flow with an application with the `provision_users` scope.
+
+The endpoints described here are considered 'application level endpoints' which is why the oauth tokens you obtain through the client credentials flow aren't tied to a user.  These tokens _cannot_ be used to access 'user level endpoints' and regular user oauth tokens cannot be used to access these application level endpoints.
+
+
+## Introduction
 
 _Note: This API is scoped to your organization’s white label._
 
@@ -120,7 +128,7 @@ Header | Description
 ```
 POST /payload HTTP/1.1
 
-Host: yourserver.com:443
+Host: yourserver.com
 User-Agent: Outstand-Webhook
 Content-Type: application/json
 Content-Length: <length>


### PR DESCRIPTION
- Remove references to old param `auth_token` authentication.
- Add docs for deprecated header `auth_token` authentication.
- Add authentication section to User Endpoints page.