### PR TITLE
ENG-1068: Adding new params to Profile API endpoint

### DIFF
--- a/endpoints/profiles.md
+++ b/endpoints/profiles.md
@@ -112,7 +112,7 @@ Returns a ```200 OK``` on success and ```404 Not Found``` if profile does not ex
 __*Note:*__ If you are sending us files __(photo, logo)__, you would send us this information as multipart form data. If you are not sending files, you can ```POST``` a JSON body.
 
 ### Optional Params
-Alternatively you can supply ```remote_photo_url``` instead of photo or ```remote_logo_url``` instead of a logo. These URLs will need to be publically accessible.
+Alternatively, you can supply a publicly accessible URL for the photo and logo with the following params:
 ```json
 {
   "remote_photo_url": "https://example.com/photo.jpg",
@@ -169,7 +169,7 @@ You can supply ```delete_photo``` to remove the photo from the profile.
   "delete_photo": 1
 }
 ```
-Alternatively you can supply ```remote_photo_url``` instead of photo or ```remote_logo_url``` instead of a logo. These URLs will need to be publically accessible.
+Alternatively, you can supply a publicly accessible URL for the photo and logo with the following params:
 ```json
 {
   "remote_photo_url": "https://example.com/photo.jpg",

--- a/endpoints/profiles.md
+++ b/endpoints/profiles.md
@@ -112,10 +112,11 @@ Returns a ```200 OK``` on success and ```404 Not Found``` if profile does not ex
 __*Note:*__ If you are sending us files __(photo, logo)__, you would send us this information as multipart form data. If you are not sending files, you can ```POST``` a JSON body.
 
 ### Optional Params
-Alternatively you can supply ```remote_photo_url``` instead of photo.
+Alternatively you can supply ```remote_photo_url``` instead of photo or ```remote_logo_url``` instead of a logo. These URLs will need to be publically accessible.
 ```json
 {
-  "remote_photo_url": "https://example.com/photo.jpg"
+  "remote_photo_url": "https://example.com/photo.jpg",
+  "remote_logo_url": "https://example.com/logo.jpg"
 }
 ```
 
@@ -168,10 +169,11 @@ You can supply ```delete_photo``` to remove the photo from the profile.
   "delete_photo": 1
 }
 ```
-Alternatively you can supply ```remote_photo_url``` to update the photo.
+Alternatively you can supply ```remote_photo_url``` instead of photo or ```remote_logo_url``` instead of a logo. These URLs will need to be publically accessible.
 ```json
 {
-  "remote_photo_url": "https://example.com/photo.jpg"
+  "remote_photo_url": "https://example.com/photo.jpg",
+  "remote_logo_url": "https://example.com/logo.jpg"
 }
 ```
 


### PR DESCRIPTION
When we did our latest work with Brand Identities, we now support using a URL for uploading the logo for profiles. This adds documentation for that new option.